### PR TITLE
JWT 인증 로직 구현

### DIFF
--- a/src/main/java/peoplehere/peoplehere/common/interceptor/JwtAuthFilter.java
+++ b/src/main/java/peoplehere/peoplehere/common/interceptor/JwtAuthFilter.java
@@ -8,6 +8,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import peoplehere.peoplehere.util.jwt.JwtProvider;
@@ -34,6 +36,8 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                 Claims claims = jwtProvider.parseToken(accessToken); // 토큰 파싱
                 String userId = claims.getSubject();
                 request.setAttribute("userId", userId);
+                Authentication authentication = jwtProvider.getAuthentication(accessToken);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
             } catch (JwtException e) {
                 log.info("Invalid JWT token: {}", e.getMessage());
             }

--- a/src/main/java/peoplehere/peoplehere/controller/UserController.java
+++ b/src/main/java/peoplehere/peoplehere/controller/UserController.java
@@ -7,7 +7,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import peoplehere.peoplehere.common.exception.UserException;
 import peoplehere.peoplehere.common.response.BaseResponse;
-import peoplehere.peoplehere.controller.dto.jwt.ResponseJwtToken;
 import peoplehere.peoplehere.controller.dto.tour.GetTourResponse;
 import peoplehere.peoplehere.controller.dto.user.*;
 import peoplehere.peoplehere.domain.User;
@@ -36,7 +35,7 @@ public class UserController {
     @PatchMapping("/{id}")
     public BaseResponse<Void> deactivateUser(@PathVariable Long id) {
         log.info("Deactivate user request for ID: {}", id);
-        // TODO: 회원탈퇴 로직 구현 예정
+        userService.deactivateUser(id);
         return new BaseResponse<>(null);
     }
 
@@ -47,8 +46,6 @@ public class UserController {
         }
         log.info("User login request: {}", request.getEmail());
         String jwt = userService.login(request);
-        // TODO: 추후에 인증 방식을 변경하면 수정 필요.
-        // TODO: 로그인 로직 구현 예정
         return new BaseResponse<>(new PostLoginResponse(jwt));
     }
 

--- a/src/main/java/peoplehere/peoplehere/domain/User.java
+++ b/src/main/java/peoplehere/peoplehere/domain/User.java
@@ -6,16 +6,19 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 import peoplehere.peoplehere.domain.util.BaseTimeEntity;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 @Entity
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class User extends BaseTimeEntity {
+public class User extends BaseTimeEntity implements UserDetails {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
@@ -69,5 +72,36 @@ public class User extends BaseTimeEntity {
 
     public void setStatus(String status) {
         this.status = status;
+    }
+
+    //TODO: 유저 권한 설정
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
     }
 }

--- a/src/main/java/peoplehere/peoplehere/service/UserDetailsServiceImpl.java
+++ b/src/main/java/peoplehere/peoplehere/service/UserDetailsServiceImpl.java
@@ -1,0 +1,27 @@
+package peoplehere.peoplehere.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import peoplehere.peoplehere.domain.User;
+import peoplehere.peoplehere.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+
+    @Override
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+        Long id = Long.valueOf(userId);
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new UsernameNotFoundException("Failed: No User Info"));
+        return user;
+    }
+}

--- a/src/main/java/peoplehere/peoplehere/service/UserService.java
+++ b/src/main/java/peoplehere/peoplehere/service/UserService.java
@@ -38,7 +38,7 @@ public class UserService {
     /**
      * 회원 탈퇴
      */
-    public void deleteUser(Long userId) {
+    public void deactivateUser(Long userId) {
         User user = userRepository.findById(userId).orElseThrow();
         user.setStatus("삭제"); //TODO: userStatus 코드 상수화 시키기
     }

--- a/src/main/java/peoplehere/peoplehere/util/jwt/JwtProvider.java
+++ b/src/main/java/peoplehere/peoplehere/util/jwt/JwtProvider.java
@@ -1,19 +1,27 @@
 package peoplehere.peoplehere.util.jwt;
 
 import io.jsonwebtoken.*;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import peoplehere.peoplehere.common.exception.jwt.bad_request.JwtUnsupportedTokenException;
 import peoplehere.peoplehere.common.exception.jwt.unauthorized.JwtMalformedTokenException;
 import peoplehere.peoplehere.common.exception.jwt.unauthorized.JwtInvalidTokenException;
 import peoplehere.peoplehere.common.exception.jwt.unauthorized.JwtExpiredTokenException;
+import peoplehere.peoplehere.service.UserDetailsServiceImpl;
 
 import java.util.Date;
 
 import static peoplehere.peoplehere.common.response.status.BaseExceptionResponseStatus.*;
 
 @Component
+@RequiredArgsConstructor
 public class JwtProvider {
+
+    private final UserDetailsServiceImpl userDetailsServiceimpl;
 
     @Value("${secret.jwt-secret-key}")
     private String jwtSecretKey;
@@ -72,6 +80,11 @@ public class JwtProvider {
         } catch (JwtException e) {
             throw new JwtInvalidTokenException(JWT_INVALID_TOKEN);
         }
+    }
+
+    public Authentication getAuthentication(String accessToken) {
+        UserDetails userDetails = userDetailsServiceimpl.loadUserByUsername(parseToken(accessToken).getSubject());
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 
 }


### PR DESCRIPTION
- JWT 인증을 위해 User Domain 을 UserDetails를 구현하도록 변경. 
- SecurityConfig , JwtProvider, UserDetails 세 클래스의 순환참조 방지를 위해  UserDetails를 구현한 Impl 서비스 추가
- JwtAuthFilter에 Authentication을 통해 저장 후 이를 통한 인증 로직 구현