### PR TITLE
S3 사진 저장로직, 이미지가 추가된 Place 및 Tour 생성 로직

### DIFF
--- a/src/main/java/peoplehere/peoplehere/controller/PlaceController.java
+++ b/src/main/java/peoplehere/peoplehere/controller/PlaceController.java
@@ -1,11 +1,14 @@
 package peoplehere.peoplehere.controller;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 import peoplehere.peoplehere.common.exception.PlaceException;
 import peoplehere.peoplehere.common.response.BaseResponse;
 import peoplehere.peoplehere.controller.dto.place.*;
+import peoplehere.peoplehere.domain.Place;
 import peoplehere.peoplehere.service.PlaceService;
 
 import static peoplehere.peoplehere.common.response.status.BaseExceptionResponseStatus.*;
@@ -18,33 +21,48 @@ public class PlaceController {
 
     private final PlaceService placeService;
 
+    /**
+     * @Param  List<PostPlaceRequest>
+     * @return List<PostPlaceResponse>
+     * 투어 내부에 있는 여러 장소를 DB에 저장한 후 반환
+     * PostPlaceRequest에 담긴 MultipartFile을 S3에 저장 후 url로 변경하여 리턴.
+     */
     @PostMapping("/new")
-    public BaseResponse<PostPlaceResponse> addPlace(@RequestBody PostPlaceRequest request) {
-        log.info("Create place request: {}", request.getAddress());
-        // TODO: 장소 생성 로직 구현 예정
-        return new BaseResponse<>(new PostPlaceResponse(1L, request.getContent(), request.getAddress(), request.getOrder()));
+    public BaseResponse<List<PostPlaceResponse>> addPlaces(@RequestBody List<PostPlaceRequest> postPlaceRequests) {
+        log.info("Create place request");
+        List<Place> places = new ArrayList<>();
+        int order = 1;
+        for (PostPlaceRequest postPlaceRequest : postPlaceRequests) {
+            postPlaceRequest.setOrder(order++);
+            places.add(placeService.createPlace(postPlaceRequest));
+        }
+        List<PostPlaceResponse> postPlaceResponses = new ArrayList<>();
+        for (Place place : places) {
+            postPlaceResponses.add(PlaceDtoConverter.placeToPostPlaceResponse(place));
+        }
+        return new BaseResponse<>(postPlaceResponses);
     }
 
-    @PutMapping("/{id}")
-    public BaseResponse<PutPlaceResponse> updatePlace(@PathVariable Long id, @RequestBody PutPlaceRequest request) {
-        log.info("Update place request for ID: {}, {}", id, request.getAddress());
-        // TODO: 장소 수정 로직 구현 예정
-        return new BaseResponse<>(new PutPlaceResponse(id, request.getContent(), request.getAddress(), request.getOrder()));
-    }
+//    @PutMapping("/{id}")
+//    public BaseResponse<PutPlaceResponse> updatePlace(@PathVariable Long id, @RequestBody PutPlaceRequest request) {
+//        log.info("Update place request for ID: {}, {}", id, request.getAddress());
+//        // TODO: 장소 수정 로직 구현 예정
+//        return new BaseResponse<>(new PutPlaceResponse(id, request.getContent(), request.getAddress(), request.getOrder()));
+//    }
+//
+//    @PatchMapping("/{id}")
+//    public BaseResponse<Void> deletePlace(@PathVariable Long id) {
+//        log.info("Delete place request for ID: {}", id);
+//        // TODO: 장소 삭제 로직 구현 예정
+//        return new BaseResponse<>(null);
+//    }
 
-    @PatchMapping("/{id}")
-    public BaseResponse<Void> deletePlace(@PathVariable Long id) {
-        log.info("Delete place request for ID: {}", id);
-        // TODO: 장소 삭제 로직 구현 예정
-        return new BaseResponse<>(null);
-    }
-
-    @GetMapping("")
-    public BaseResponse<GetPlacesResponse> getAllPlaces() {
-        log.info("Get all places request");
-        // TODO: 모든 장소 조회 로직 구현 예정
-        return new BaseResponse<>(new GetPlacesResponse());
-    }
+//    @GetMapping("")
+//    public BaseResponse<GetPlacesResponse> getAllPlaces() {
+//        log.info("Get all places request");
+//        // TODO: 모든 장소 조회 로직 구현 예정
+//        return new BaseResponse<>(new GetPlacesResponse());
+//    }
 
     @GetMapping("/{id}")
     public BaseResponse<GetPlaceResponse> getPlace(@PathVariable Long id) {

--- a/src/main/java/peoplehere/peoplehere/controller/PlaceController.java
+++ b/src/main/java/peoplehere/peoplehere/controller/PlaceController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import peoplehere.peoplehere.common.exception.PlaceException;
 import peoplehere.peoplehere.common.response.BaseResponse;
 import peoplehere.peoplehere.controller.dto.place.*;
@@ -28,13 +29,14 @@ public class PlaceController {
      * PostPlaceRequest에 담긴 MultipartFile을 S3에 저장 후 url로 변경하여 리턴.
      */
     @PostMapping("/new")
-    public BaseResponse<List<PostPlaceResponse>> addPlaces(@RequestBody List<PostPlaceRequest> postPlaceRequests) {
+    public BaseResponse<List<PostPlaceResponse>> addPlaces(@RequestPart("images") List<MultipartFile> images,
+        @RequestPart List<PostPlaceRequest> postPlaceRequests) {
         log.info("Create place request");
         List<Place> places = new ArrayList<>();
         int order = 1;
         for (PostPlaceRequest postPlaceRequest : postPlaceRequests) {
             postPlaceRequest.setOrder(order++);
-            places.add(placeService.createPlace(postPlaceRequest));
+            places.add(placeService.createPlace(postPlaceRequest, images));
         }
         List<PostPlaceResponse> postPlaceResponses = new ArrayList<>();
         for (Place place : places) {

--- a/src/main/java/peoplehere/peoplehere/controller/dto/place/GetPlaceResponse.java
+++ b/src/main/java/peoplehere/peoplehere/controller/dto/place/GetPlaceResponse.java
@@ -1,5 +1,6 @@
 package peoplehere.peoplehere.controller.dto.place;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,7 +13,7 @@ import lombok.Setter;
 public class GetPlaceResponse {
     private Long id;
     private String content;
-    private String imageUrl;
+    private List<String> imageUrls;
     private String address;
     private int order;
     private Long tourId;

--- a/src/main/java/peoplehere/peoplehere/controller/dto/place/GetPlacesResponse.java
+++ b/src/main/java/peoplehere/peoplehere/controller/dto/place/GetPlacesResponse.java
@@ -1,29 +1,29 @@
-package peoplehere.peoplehere.controller.dto.place;
-
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-
-import java.util.List;
-
-@Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
-public class GetPlacesResponse {
-    private List<PlaceInfo> places;
-
-    @Getter
-    @Setter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class PlaceInfo {
-        private Long id;
-        private String content;
-        private String imageUrl;
-        private String address;
-        private int order;
-        private Long tourId;
-    }
-}
+//package peoplehere.peoplehere.controller.dto.place;
+//
+//import lombok.AllArgsConstructor;
+//import lombok.Getter;
+//import lombok.NoArgsConstructor;
+//import lombok.Setter;
+//
+//import java.util.List;
+//
+//@Getter
+//@Setter
+//@NoArgsConstructor
+//@AllArgsConstructor
+//public class GetPlacesResponse {
+//    private List<PlaceInfo> places;
+//
+//    @Getter
+//    @Setter
+//    @NoArgsConstructor
+//    @AllArgsConstructor
+//    public static class PlaceInfo {
+//        private Long id;
+//        private String content;
+//        private String imageUrl;
+//        private String address;
+//        private int order;
+//        private Long tourId;
+//    }
+//}

--- a/src/main/java/peoplehere/peoplehere/controller/dto/place/PlaceDtoConverter.java
+++ b/src/main/java/peoplehere/peoplehere/controller/dto/place/PlaceDtoConverter.java
@@ -10,4 +10,18 @@ public class PlaceDtoConverter {
                 placeInfoDto.getOrder()
         );
     }
+
+    /**
+     * @return 사진 정보가 담기지 않은 Place
+     */
+    public static Place postPlaceRequestToPlace(PostPlaceRequest postPlaceRequest){
+        return new Place(postPlaceRequest.getContent(), null, postPlaceRequest.getAddress(),
+            postPlaceRequest.getOrder());
+    }
+
+    public static PostPlaceResponse placeToPostPlaceResponse(Place place) {
+        return new PostPlaceResponse(place.getId(), place.getContent(), place.getImageUrls(),
+            place.getAddress(),
+            place.getOrder());
+    }
 }

--- a/src/main/java/peoplehere/peoplehere/controller/dto/place/PlaceDtoConverter.java
+++ b/src/main/java/peoplehere/peoplehere/controller/dto/place/PlaceDtoConverter.java
@@ -1,5 +1,6 @@
 package peoplehere.peoplehere.controller.dto.place;
 
+import java.util.ArrayList;
 import peoplehere.peoplehere.domain.Place;
 
 public class PlaceDtoConverter {
@@ -15,7 +16,7 @@ public class PlaceDtoConverter {
      * @return 사진 정보가 담기지 않은 Place
      */
     public static Place postPlaceRequestToPlace(PostPlaceRequest postPlaceRequest){
-        return new Place(postPlaceRequest.getContent(), null, postPlaceRequest.getAddress(),
+        return new Place(postPlaceRequest.getContent(), new ArrayList<String>(), postPlaceRequest.getAddress(),
             postPlaceRequest.getOrder());
     }
 

--- a/src/main/java/peoplehere/peoplehere/controller/dto/place/PostPlaceRequest.java
+++ b/src/main/java/peoplehere/peoplehere/controller/dto/place/PostPlaceRequest.java
@@ -1,18 +1,19 @@
 package peoplehere.peoplehere.controller.dto.place;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class PostPlaceRequest { // 구글맵 API 특성상 제약조건 불필요
-    private String content;
-    private String imageUrl;
+    private String content; //구글 기본 장소 설명..? 필요 없기는 할듯?
+    private List<MultipartFile> images;
     private String address;
     private int order;
-    private Long tourId;
 }

--- a/src/main/java/peoplehere/peoplehere/controller/dto/place/PostPlaceRequest.java
+++ b/src/main/java/peoplehere/peoplehere/controller/dto/place/PostPlaceRequest.java
@@ -13,7 +13,7 @@ import org.springframework.web.multipart.MultipartFile;
 @AllArgsConstructor
 public class PostPlaceRequest { // 구글맵 API 특성상 제약조건 불필요
     private String content; //구글 기본 장소 설명..? 필요 없기는 할듯?
-    private List<MultipartFile> images;
+//    private List<MultipartFile> images;
     private String address;
     private int order;
 }

--- a/src/main/java/peoplehere/peoplehere/controller/dto/place/PostPlaceResponse.java
+++ b/src/main/java/peoplehere/peoplehere/controller/dto/place/PostPlaceResponse.java
@@ -1,5 +1,6 @@
 package peoplehere.peoplehere.controller.dto.place;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,14 +13,15 @@ import lombok.Setter;
 public class PostPlaceResponse {
     private Long id;
     private String content;
-    private String imageUrl;
+    private List<String> imageUrls;
     private String address;
     private int order;
     private Long tourId;
 
-    public PostPlaceResponse(Long id, String content, String address, int order) {
+    public PostPlaceResponse(Long id, String content, List<String> imageUrls, String address, int order) {
         this.id = id;
         this.content = content;
+        this.imageUrls = imageUrls;
         this.address = address;
         this.order = order;
     }

--- a/src/main/java/peoplehere/peoplehere/controller/dto/tour/PostTourRequest.java
+++ b/src/main/java/peoplehere/peoplehere/controller/dto/tour/PostTourRequest.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
+import peoplehere.peoplehere.controller.dto.place.PostPlaceResponse;
 
 @Getter
 @Setter
@@ -33,5 +34,5 @@ public class PostTourRequest {
 
     // TODO: notice 필드 추가 필요.
 
-    private List<PlaceInfoDto> places;
+    private List<PostPlaceResponse> places;
 }

--- a/src/main/java/peoplehere/peoplehere/domain/Place.java
+++ b/src/main/java/peoplehere/peoplehere/domain/Place.java
@@ -47,6 +47,10 @@ public class Place extends BaseTimeEntity {
     @ColumnDefault("'일반'")
     private String status = "일반";
 
+    public void addImageUrls(String imageUrl){
+        imageUrls.add(imageUrl);
+    }
+
     //==연관관계 편의 메서드==//
     public void setTour(Tour tour) {
         this.tour = tour;

--- a/src/main/java/peoplehere/peoplehere/repository/PlaceRepository.java
+++ b/src/main/java/peoplehere/peoplehere/repository/PlaceRepository.java
@@ -1,0 +1,8 @@
+package peoplehere.peoplehere.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import peoplehere.peoplehere.domain.Place;
+
+public interface PlaceRepository extends JpaRepository<Place, Long> {
+
+}

--- a/src/main/java/peoplehere/peoplehere/service/PlaceService.java
+++ b/src/main/java/peoplehere/peoplehere/service/PlaceService.java
@@ -34,9 +34,8 @@ public class PlaceService {
         }
     }
 
-    public Place createPlace(PostPlaceRequest postPlaceRequest) {
+    public Place createPlace(PostPlaceRequest postPlaceRequest, List<MultipartFile> images) {
         Place place = PlaceDtoConverter.postPlaceRequestToPlace(postPlaceRequest);
-        List<MultipartFile> images = postPlaceRequest.getImages();
         saveImages(place, images);
         placeRepository.save(place);
         return place;

--- a/src/main/java/peoplehere/peoplehere/service/PlaceService.java
+++ b/src/main/java/peoplehere/peoplehere/service/PlaceService.java
@@ -1,9 +1,17 @@
 package peoplehere.peoplehere.service;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import peoplehere.peoplehere.controller.dto.place.PlaceDtoConverter;
+import peoplehere.peoplehere.controller.dto.place.PostPlaceRequest;
+import peoplehere.peoplehere.controller.dto.place.PostPlaceResponse;
+import peoplehere.peoplehere.domain.Place;
+import peoplehere.peoplehere.repository.PlaceRepository;
 import peoplehere.peoplehere.repository.UserRepository;
 
 @Slf4j
@@ -11,4 +19,26 @@ import peoplehere.peoplehere.repository.UserRepository;
 @RequiredArgsConstructor
 @Transactional
 public class PlaceService {
+
+    private final S3Service s3Service;
+    private final PlaceRepository placeRepository;
+
+    /**
+     * 이미지를 S3에 저장 후 반환 된 url을 Place에 담아줌
+     *
+     */
+    public void saveImages(Place place, List<MultipartFile> images) {
+        for (MultipartFile image : images) {
+            String storedName = s3Service.saveMultipartFileToS3(image); //S3에 파일 저장
+            place.addImageUrls(s3Service.getPictureS3Url(storedName));  //DB에는 파일 URL만 저장
+        }
+    }
+
+    public Place createPlace(PostPlaceRequest postPlaceRequest) {
+        Place place = PlaceDtoConverter.postPlaceRequestToPlace(postPlaceRequest);
+        List<MultipartFile> images = postPlaceRequest.getImages();
+        saveImages(place, images);
+        placeRepository.save(place);
+        return place;
+    }
 }

--- a/src/main/java/peoplehere/peoplehere/service/TourService.java
+++ b/src/main/java/peoplehere/peoplehere/service/TourService.java
@@ -7,12 +7,14 @@ import org.springframework.transaction.annotation.Transactional;
 import peoplehere.peoplehere.common.exception.TourException;
 import peoplehere.peoplehere.controller.dto.place.PlaceDtoConverter;
 import peoplehere.peoplehere.controller.dto.place.PlaceInfoDto;
+import peoplehere.peoplehere.controller.dto.place.PostPlaceResponse;
 import peoplehere.peoplehere.controller.dto.tour.PostTourRequest;
 import peoplehere.peoplehere.controller.dto.tour.PutTourRequest;
 import peoplehere.peoplehere.controller.dto.tour.TourDtoConverter;
 import peoplehere.peoplehere.domain.enums.Status;
 import peoplehere.peoplehere.domain.*;
 import peoplehere.peoplehere.repository.CategoryRepository;
+import peoplehere.peoplehere.repository.PlaceRepository;
 import peoplehere.peoplehere.repository.TourCategoryRepository;
 import peoplehere.peoplehere.repository.TourRepository;
 import peoplehere.peoplehere.repository.UserRepository;
@@ -37,6 +39,7 @@ public class TourService {
     private final UserRepository userRepository;
     private final CategoryRepository categoryRepository;
     private final TourCategoryRepository tourCategoryRepository;
+    private final PlaceRepository placeRepository;
 
     /**
      * 모든 투어 조회
@@ -86,12 +89,10 @@ public class TourService {
         tour.setUser(user);
 
         // 장소 설정
+        List<PostPlaceResponse> postTourRequestPlaces = postTourRequest.getPlaces();
         List<Place> places = new ArrayList<>();
-        int order = 1;
-        for (PlaceInfoDto placeInfoDto : postTourRequest.getPlaces()) {
-            Place place = PlaceDtoConverter.placeInfoDtoToPlace(placeInfoDto);
-            place.setOrder(order++); // 순서를 리스트의 순서대로 할당
-            place.setImageUrls(placeInfoDto.getImageUrls());
+        for (PostPlaceResponse postTourRequestPlace : postTourRequestPlaces) {
+            Place place = placeRepository.findById(postTourRequestPlace.getId()).orElseThrow();
             place.setTour(tour);
             places.add(place);
         }


### PR DESCRIPTION
- S3에 사진을 업로드 할 때 UUID를 통해 파일명을 설정
- 사진을 S3에 저장하면 해당 사진이 저장된 URL 반환
- DB에는 해당 사진들의 URL만 담음
- 장소 저장, 투어 생성 로직
장소에 사진을 업로드 하고 다음 버튼을 누를 때 장소 저장 -> 이후 투어에 나머지 정보 입력하고 투어 저장하면, 투어가 생성되고 이 투어와 장소를 매핑시켜준다.