### PR TITLE
장소에 이미지 저장 로직 변경

### DIFF
--- a/src/main/java/peoplehere/peoplehere/controller/PlaceController.java
+++ b/src/main/java/peoplehere/peoplehere/controller/PlaceController.java
@@ -5,7 +5,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 import peoplehere.peoplehere.common.exception.PlaceException;
 import peoplehere.peoplehere.common.response.BaseResponse;
 import peoplehere.peoplehere.controller.dto.place.*;
@@ -22,27 +21,28 @@ public class PlaceController {
 
     private final PlaceService placeService;
 
-    /**
-     * @Param  List<PostPlaceRequest>
-     * @return List<PostPlaceResponse>
-     * 투어 내부에 있는 여러 장소를 DB에 저장한 후 반환
-     * PostPlaceRequest에 담긴 MultipartFile을 S3에 저장 후 url로 변경하여 리턴.
-     */
     @PostMapping("/new")
-    public BaseResponse<List<PostPlaceResponse>> addPlaces(@RequestPart("images") List<MultipartFile> images,
-        @RequestPart List<PostPlaceRequest> postPlaceRequests) {
+    public BaseResponse<List<PostPlaceResponse>> addPlaces(@RequestBody List<PostPlaceRequest> postPlaceRequests) {
         log.info("Create place request");
         List<Place> places = new ArrayList<>();
         int order = 1;
         for (PostPlaceRequest postPlaceRequest : postPlaceRequests) {
             postPlaceRequest.setOrder(order++);
-            places.add(placeService.createPlace(postPlaceRequest, images));
+            places.add(placeService.createPlace(postPlaceRequest));
         }
         List<PostPlaceResponse> postPlaceResponses = new ArrayList<>();
         for (Place place : places) {
             postPlaceResponses.add(PlaceDtoConverter.placeToPostPlaceResponse(place));
         }
         return new BaseResponse<>(postPlaceResponses);
+    }
+
+    @GetMapping("/{id}")
+    public BaseResponse<GetPlaceResponse> getPlace(@PathVariable Long id) {
+        log.info("Get place request for ID: {}", id);
+        GetPlaceResponse placeResponse = placeService.getPlace(id);
+        return new BaseResponse<>(placeResponse);
+//        throw new PlaceException(PLACE_NOT_FOUND, "Place ID: " + id + " not found");
     }
 
 //    @PutMapping("/{id}")
@@ -57,19 +57,13 @@ public class PlaceController {
 //        log.info("Delete place request for ID: {}", id);
 //        // TODO: 장소 삭제 로직 구현 예정
 //        return new BaseResponse<>(null);
-//    }
 
+//    }
 //    @GetMapping("")
 //    public BaseResponse<GetPlacesResponse> getAllPlaces() {
 //        log.info("Get all places request");
 //        // TODO: 모든 장소 조회 로직 구현 예정
 //        return new BaseResponse<>(new GetPlacesResponse());
-//    }
 
-    @GetMapping("/{id}")
-    public BaseResponse<GetPlaceResponse> getPlace(@PathVariable Long id) {
-        log.info("Get place request for ID: {}", id);
-        // TODO: 특정 장소 조회 로직 구현 예정
-        throw new PlaceException(PLACE_NOT_FOUND, "Place ID: " + id + " not found");
-    }
+//    }
 }

--- a/src/main/java/peoplehere/peoplehere/controller/dto/place/PostImageRequest.java
+++ b/src/main/java/peoplehere/peoplehere/controller/dto/place/PostImageRequest.java
@@ -1,6 +1,5 @@
 package peoplehere.peoplehere.controller.dto.place;
 
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,10 +9,9 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class GetPlaceResponse {
-    private Long id;
-    private List<String> imageUrls;
-    private String address;
-    private int order;
-    private Long tourId;
+public class PostImageRequest {
+
+    private String encodingString;
+    private String originalFileName;
+
 }

--- a/src/main/java/peoplehere/peoplehere/controller/dto/place/PostPlaceRequest.java
+++ b/src/main/java/peoplehere/peoplehere/controller/dto/place/PostPlaceRequest.java
@@ -5,15 +5,14 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class PostPlaceRequest { // 구글맵 API 특성상 제약조건 불필요
-    private String content; //구글 기본 장소 설명..? 필요 없기는 할듯?
-//    private List<MultipartFile> images;
+public class PostPlaceRequest {
+    private String content;
+    private List<PostImageRequest> imageRequests;
     private String address;
     private int order;
 }

--- a/src/main/java/peoplehere/peoplehere/service/PlaceService.java
+++ b/src/main/java/peoplehere/peoplehere/service/PlaceService.java
@@ -1,18 +1,16 @@
 package peoplehere.peoplehere.service;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Base64;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
+import peoplehere.peoplehere.controller.dto.place.GetPlaceResponse;
 import peoplehere.peoplehere.controller.dto.place.PlaceDtoConverter;
+import peoplehere.peoplehere.controller.dto.place.PostImageRequest;
 import peoplehere.peoplehere.controller.dto.place.PostPlaceRequest;
-import peoplehere.peoplehere.controller.dto.place.PostPlaceResponse;
 import peoplehere.peoplehere.domain.Place;
 import peoplehere.peoplehere.repository.PlaceRepository;
-import peoplehere.peoplehere.repository.UserRepository;
 
 @Slf4j
 @Service
@@ -23,21 +21,32 @@ public class PlaceService {
     private final S3Service s3Service;
     private final PlaceRepository placeRepository;
 
-    /**
-     * 이미지를 S3에 저장 후 반환 된 url을 Place에 담아줌
-     *
-     */
-    public void saveImages(Place place, List<MultipartFile> images) {
-        for (MultipartFile image : images) {
-            String storedName = s3Service.saveMultipartFileToS3(image); //S3에 파일 저장
-            place.addImageUrls(s3Service.getPictureS3Url(storedName));  //DB에는 파일 URL만 저장
+    //이미지를 Decoding 하고 S3에 저장한 뒤, 저장 된 URL을 place에 담아줌
+    public void saveImages(Place place, PostPlaceRequest postPlaceRequests) {
+        for (PostImageRequest imageRequest : postPlaceRequests.getImageRequests()) {
+            byte[] decodingImage = decodeBase64ToFile(imageRequest.getEncodingString()); //decoding
+            String storedFileName = s3Service.saveByteArrayToS3(decodingImage,
+                imageRequest.getOriginalFileName()); //S3에 파일 저장
+            place.addImageUrls(s3Service.getPictureS3Url(storedFileName));  //DB에는 파일 URL만 저장
         }
     }
 
-    public Place createPlace(PostPlaceRequest postPlaceRequest, List<MultipartFile> images) {
+    //장소 객체를 만들고, 이미지 저장 로직을 거쳐 객체를 DB에 저장
+    public Place createPlace(PostPlaceRequest postPlaceRequest) {
         Place place = PlaceDtoConverter.postPlaceRequestToPlace(postPlaceRequest);
-        saveImages(place, images);
+        saveImages(place, postPlaceRequest);
         placeRepository.save(place);
         return place;
+    }
+
+    //Base64로 decoding 하기 위한 메서드
+    public byte[] decodeBase64ToFile(String encodingString) {
+        return Base64.getDecoder().decode(encodingString);
+    }
+
+    public GetPlaceResponse getPlace(Long id) {
+        Place place = placeRepository.findById(id).orElseThrow();
+        return new GetPlaceResponse(id, place.getImageUrls(), place.getAddress(), place.getOrder(),
+            place.getTour().getId());
     }
 }

--- a/src/main/java/peoplehere/peoplehere/service/S3Service.java
+++ b/src/main/java/peoplehere/peoplehere/service/S3Service.java
@@ -2,19 +2,13 @@
 package peoplehere.peoplehere.service;
 
 import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.amazonaws.services.s3.model.S3Object;
-import com.amazonaws.services.s3.model.S3ObjectInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.ByteArrayInputStream;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -26,38 +20,17 @@ public class S3Service {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    public byte[] getPictureBytesFromS3(String storedName) throws IOException {
-        S3Object object = amazonS3Client.getObject(bucket, storedName);
-        S3ObjectInputStream is = object.getObjectContent();
-        return is.readAllBytes();
-    }
-
     public String getPictureS3Url(String storedName) {
         return amazonS3Client.getUrl(bucket, storedName).toString();
     }
 
-    //파일의 ByteArray와 파일 정보를 통해 S3에 파일 업로드
-    public String saveMultipartFileToS3(MultipartFile file) {
-
-        //파일 이름 생성
-        String fileName = createFileName(file.getOriginalFilename());
-
-        //파일 변환
-        ObjectMetadata objectMetadata = new ObjectMetadata();
-        objectMetadata.setContentLength(file.getSize());
-        objectMetadata.setContentType(file.getContentType());
-
-        //파일 업로드
-        try(InputStream inputStream = file.getInputStream()) {
-            amazonS3Client.putObject(
-                new PutObjectRequest(bucket, fileName, inputStream, objectMetadata).withCannedAcl(
-                    CannedAccessControlList.PublicReadWrite)
-            );
-        } catch (IOException e) {
-            throw new IllegalArgumentException(String.format("파일 변환 중 에러가 발생하였습니다. (%s)", file.getOriginalFilename()));
-        }
-
-        return fileName;
+    //S3에 파일 저장 후 UUID로 생성 된 이름 return
+    public String saveByteArrayToS3(byte[] pictureFileByteArray, String originalFileName) {
+        String storedFileName = createFileName(originalFileName);
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(getFileExtension(originalFileName));
+        amazonS3Client.putObject(bucket, storedFileName, new ByteArrayInputStream(pictureFileByteArray), metadata);
+        return storedFileName;
     }
 
     //파일 이름 생성 로직


### PR DESCRIPTION
- 호출 한 번에 모든 장소를 저장할 수 있도록 장소에 이미지 저장을 MultipartFile을 이용하는 로직에서 Base64 Encoding 방식으로 변경하였습니다.
- 이미지를 Base64로 Encoding하여 String형태로 전달받으며, 원본 파일 이름과 함께 PostImageRequest로 전달 받습니다.