### PR TITLE
feat: 투어 별 참여 요청 리스트 조회 구현

### DIFF
--- a/src/main/java/peoplehere/peoplehere/controller/TourDateController.java
+++ b/src/main/java/peoplehere/peoplehere/controller/TourDateController.java
@@ -22,20 +22,22 @@ public class TourDateController {
     private final TourDateService tourDateService;
 
     @PostMapping("/{tourId}/dates")
-    public BaseResponse<Void> addOrUpdateTourDate(@PathVariable Long tourId, @Valid @RequestBody PostTourDateRequest request) {
+    public BaseResponse<Void> addOrUpdateTourDate(@PathVariable Long tourId,
+        @Valid @RequestBody PostTourDateRequest request) {
         tourDateService.addOrUpdateTourDate(tourId, request.getDate(), request.getTime());
         return new BaseResponse<>(null);
     }
 
     @PatchMapping("/{tourDateId}/status")
-    public BaseResponse<Void> updateTourDateStatus(@PathVariable Long tourDateId, @RequestParam TourDateStatus status) {
+    public BaseResponse<Void> updateTourDateStatus(@PathVariable Long tourDateId,
+        @RequestParam TourDateStatus status) {
         tourDateService.updateTourDateStatus(tourDateId, status);
         return new BaseResponse<>(null);
     }
 
     @GetMapping("/{tourId}/dates")
     public BaseResponse<List<GetTourDatesResponse>> getAllTourDates(
-            @PathVariable Long tourId) {
+        @PathVariable Long tourId) {
         List<GetTourDatesResponse> responses = tourDateService.getTourDates(tourId);
         return new BaseResponse<>(responses);
     }
@@ -48,15 +50,28 @@ public class TourDateController {
 
 
     @PostMapping("/{tourDateId}/join")
-    public BaseResponse<String> joinTour(Authentication authentication, @PathVariable Long tourDateId) {
+    public BaseResponse<String> joinTour(Authentication authentication,
+        @PathVariable Long tourDateId) {
         tourDateService.joinTourDate(authentication, tourDateId);
         return new BaseResponse<>("Current user joined tour date " + tourDateId);
     }
 
     @PatchMapping("/{tourHistoryId}/reservation-status")
-    public BaseResponse<Void> updateTourStatus(@PathVariable Long tourHistoryId, @RequestParam TourHistoryStatus status) {
-        log.info("Update tour history status request for ID: {}, Status: {}", tourHistoryId, status);
+    public BaseResponse<Void> updateTourStatus(@PathVariable Long tourHistoryId,
+        @RequestParam TourHistoryStatus status) {
+        log.info("Update tour history status request for ID: {}, Status: {}", tourHistoryId,
+            status);
         tourDateService.updateReservationStatus(tourHistoryId, status);
         return new BaseResponse<>(null);
+    }
+
+    /**
+     * 한 투어에 대한 참여 요청들 조회
+     */
+    @GetMapping("/participants/{tourId}")
+    public BaseResponse<List<GetTourParticipantsResponse>> getParticipantRequests(@PathVariable Long tourId) {
+        List<GetTourParticipantsResponse> participantRequests = tourDateService.getParticipantRequests(
+            tourId);
+        return new BaseResponse<>(participantRequests);
     }
 }

--- a/src/main/java/peoplehere/peoplehere/controller/dto/chat/GetParticipationRequest.java
+++ b/src/main/java/peoplehere/peoplehere/controller/dto/chat/GetParticipationRequest.java
@@ -1,0 +1,2 @@
+package peoplehere.peoplehere.controller.dto.chat;public class GetParticipationRequest {
+}

--- a/src/main/java/peoplehere/peoplehere/controller/dto/tour/GetTourParticipantsResponse.java
+++ b/src/main/java/peoplehere/peoplehere/controller/dto/tour/GetTourParticipantsResponse.java
@@ -1,0 +1,27 @@
+package peoplehere.peoplehere.controller.dto.tour;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import peoplehere.peoplehere.controller.dto.user.UserInfoDto;
+import peoplehere.peoplehere.domain.enums.TourDateStatus;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetTourParticipantsResponse {
+    private Long tourHistoryId;
+    private Long tourDateId;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate date;
+    @JsonFormat(pattern = "HH:mm:ss")
+    private LocalTime time;
+    private TourDateStatus status;
+    private UserInfoDto participants;
+
+}

--- a/src/main/java/peoplehere/peoplehere/repository/TourHistoryRepository.java
+++ b/src/main/java/peoplehere/peoplehere/repository/TourHistoryRepository.java
@@ -1,15 +1,17 @@
 package peoplehere.peoplehere.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import peoplehere.peoplehere.domain.Tour;
 import peoplehere.peoplehere.domain.TourHistory;
 import peoplehere.peoplehere.domain.User;
 import peoplehere.peoplehere.domain.enums.TourHistoryStatus;
 
-import java.util.Collection;
 import java.util.List;
 
 public interface TourHistoryRepository extends JpaRepository<TourHistory, Long> {
     List<TourHistory> findAllByUserAndStatus(User currentUser, TourHistoryStatus tourHistoryStatus);
 
     List<TourHistory> findAllByTourUserAndStatus(User currentUser, TourHistoryStatus tourHistoryStatus);
+
+    List<TourHistory> findAllByTourAndStatus(Tour tour, TourHistoryStatus tourHistoryStatus);
 }

--- a/src/main/java/peoplehere/peoplehere/service/TourDateService.java
+++ b/src/main/java/peoplehere/peoplehere/service/TourDateService.java
@@ -1,5 +1,6 @@
 package peoplehere.peoplehere.service;
 
+import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
@@ -8,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import peoplehere.peoplehere.common.exception.TourException;
 import peoplehere.peoplehere.common.exception.UserException;
 import peoplehere.peoplehere.controller.dto.tour.GetTourDatesResponse;
+import peoplehere.peoplehere.controller.dto.tour.GetTourParticipantsResponse;
 import peoplehere.peoplehere.controller.dto.tour.TourDateDtoConverter;
 import peoplehere.peoplehere.controller.dto.tour.TourDateInfoDto;
 import peoplehere.peoplehere.controller.dto.user.UserInfoDto;
@@ -44,22 +46,25 @@ public class TourDateService {
      */
     public List<GetTourDatesResponse> getTourDates(Long tourId) {
         Tour tour = tourRepository.findById(tourId)
-                .orElseThrow(() -> new TourException(TOUR_NOT_FOUND));
+            .orElseThrow(() -> new TourException(TOUR_NOT_FOUND));
 
         LocalDate today = LocalDate.now();
         return tour.getTourDates().stream()
-                .filter(tourDate -> tourDate.getDate().isAfter(today) || tourDate.getDate().isEqual(today))
-                .filter(tourDate -> tourDate.getStatus() == TourDateStatus.AVAILABLE)
-                .map(tourDate -> {
-                    GetTourDatesResponse response = TourDateDtoConverter.tourDateToGetTourDatesResponse(tourDate);
-                    List<UserInfoDto> participants = tourDate.getTourHistories().stream()
-                            .filter(th -> th.getStatus() == TourHistoryStatus.CONFIRMED)
-                            .map(th -> new UserInfoDto(th.getUser().getId(), th.getUser().getFirstName(), th.getUser().getImageUrl()))
-                            .toList();
-                    response.setParticipants(participants);
-                    return response;
-                })
-                .toList();
+            .filter(
+                tourDate -> tourDate.getDate().isAfter(today) || tourDate.getDate().isEqual(today))
+            .filter(tourDate -> tourDate.getStatus() == TourDateStatus.AVAILABLE)
+            .map(tourDate -> {
+                GetTourDatesResponse response = TourDateDtoConverter.tourDateToGetTourDatesResponse(
+                    tourDate);
+                List<UserInfoDto> participants = tourDate.getTourHistories().stream()
+                    .filter(th -> th.getStatus() == TourHistoryStatus.CONFIRMED)
+                    .map(th -> new UserInfoDto(th.getUser().getId(), th.getUser().getFirstName(),
+                        th.getUser().getImageUrl()))
+                    .toList();
+                response.setParticipants(participants);
+                return response;
+            })
+            .toList();
     }
 
     /**
@@ -67,7 +72,7 @@ public class TourDateService {
      */
     public TourDateInfoDto getTourDateInfo(Long tourDateId) {
         TourDate tourDate = tourDateRepository.findById(tourDateId)
-                .orElseThrow(() -> new TourException(TOUR_DATE_NOT_FOUND));
+            .orElseThrow(() -> new TourException(TOUR_DATE_NOT_FOUND));
         return TourDateDtoConverter.convertToTourDateInfoDto(tourDate);
     }
 
@@ -75,14 +80,14 @@ public class TourDateService {
      * 투어 참여
      */
     public void joinTourDate(Authentication authentication, Long tourDateId) {
-        TourDate tourDate  = tourDateRepository.findById(tourDateId)
-                .orElseThrow(() -> new TourException(TOUR_DATE_NOT_FOUND));
+        TourDate tourDate = tourDateRepository.findById(tourDateId)
+            .orElseThrow(() -> new TourException(TOUR_DATE_NOT_FOUND));
         if (authentication == null || authentication.getPrincipal() == null) {
             throw new UserException(USER_NOT_LOGGED_IN);
         }
         UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
         User user = userRepository.findById(userDetails.getId())
-                .orElseThrow(() -> new UserException(USER_NOT_FOUND));
+            .orElseThrow(() -> new UserException(USER_NOT_FOUND));
 
         // 해당 일정의 투어 상태가 ACTIVE가 아니면 참여 불가
         if (tourDate.getTour().getStatus() != Status.ACTIVE) {
@@ -99,7 +104,8 @@ public class TourDateService {
 
         // 이미 참여한 경우 중복 참여 방지
         boolean alreadyJoined = tourDate.getTour().getTourHistories().stream()
-                .anyMatch(th -> th.getUser().getId().equals(user.getId()) && th.getTourDate().equals(tourDate));
+            .anyMatch(th -> th.getUser().getId().equals(user.getId()) && th.getTourDate()
+                .equals(tourDate));
         if (alreadyJoined) {
             throw new TourException(TOUR_ALREADY_JOINED);
         }
@@ -119,35 +125,35 @@ public class TourDateService {
     @Transactional
     public void addOrUpdateTourDate(Long tourId, LocalDate date, LocalTime time) {
         Tour tour = tourRepository.findById(tourId)
-                .orElseThrow(() -> new TourException(TOUR_NOT_FOUND));
+            .orElseThrow(() -> new TourException(TOUR_NOT_FOUND));
 
         validateTourDate(date, time);
 
         // 해당 날짜에 대한 TourDate 객체 찾기
         Optional<TourDate> existingTourDate = tour.getTourDates().stream()
-                .filter(td -> td.getDate().equals(date))
-                .findFirst();
-
+            .filter(td -> td.getDate().equals(date))
+            .findFirst();
 
         existingTourDate.ifPresentOrElse(
-                tourDate -> {
-                    if (time != null) {
-                        tourDate.setTime(time);
-                    }
-                    tourDate.makeAvailable();
-                },
-                () -> {
-                    TourDate newTourDate = new TourDate();
-                    newTourDate.setDate(date);
-                    if (time != null) {
-                        newTourDate.setTime(time);
-                    }
-                    newTourDate.makeAvailable();
-                    tour.addTourDate(newTourDate);
-                    tourDateRepository.save(newTourDate);
+            tourDate -> {
+                if (time != null) {
+                    tourDate.setTime(time);
                 }
+                tourDate.makeAvailable();
+            },
+            () -> {
+                TourDate newTourDate = new TourDate();
+                newTourDate.setDate(date);
+                if (time != null) {
+                    newTourDate.setTime(time);
+                }
+                newTourDate.makeAvailable();
+                tour.addTourDate(newTourDate);
+                tourDateRepository.save(newTourDate);
+            }
         );
     }
+
     private void validateTourDate(LocalDate date, LocalTime time) {
 
         LocalDateTime localDateTime;
@@ -163,12 +169,13 @@ public class TourDateService {
             throw new TourException(TOUR_DATE_IN_PAST);
         }
     }
+
     /**
      * 투어 일정 삭제
      */
     public void updateTourDateStatus(Long tourDateId, TourDateStatus status) {
         TourDate tourDate = tourDateRepository.findById(tourDateId)
-                .orElseThrow(() -> new TourException(TOUR_DATE_NOT_FOUND));
+            .orElseThrow(() -> new TourException(TOUR_DATE_NOT_FOUND));
         tourDate.setStatus(status);
         tourDateRepository.save(tourDate);
     }
@@ -178,7 +185,7 @@ public class TourDateService {
      */
     public void updateReservationStatus(Long tourHistoryId, TourHistoryStatus status) {
         TourHistory tourHistory = tourHistoryRepository.findById(tourHistoryId)
-                .orElseThrow(() -> new TourException(TOUR_HISTORY_NOT_FOUND));
+            .orElseThrow(() -> new TourException(TOUR_HISTORY_NOT_FOUND));
 
         if (!tourHistory.getStatus().equals(TourHistoryStatus.RESERVED)) {
             throw new TourException(INVALID_TOUR_HISTORY_STATUS);
@@ -186,6 +193,32 @@ public class TourDateService {
 
         tourHistory.setStatus(status);
         tourHistoryRepository.save(tourHistory);
+    }
+
+    /**
+     * TODO: 채팅으로 로직 변경
+     * 한 투어에 대한 참여 요청들 조회
+     */
+    public List<GetTourParticipantsResponse> getParticipantRequests(Long tourId) {
+        Tour tour = tourRepository.findById(tourId)
+            .orElseThrow(() -> new TourException(TOUR_NOT_FOUND));
+
+        List<TourHistory> tourHistories = tourHistoryRepository.findAllByTourAndStatus(tour,
+            TourHistoryStatus.RESERVED);
+
+        List<GetTourParticipantsResponse> getTourDatesResponses = new ArrayList<>();
+
+        for (TourHistory tourHistory : tourHistories) {
+            User user = userRepository.findById(tourHistory.getUser().getId()).orElseThrow();
+            TourDate tourDate = tourHistory.getTourDate();
+            UserInfoDto userInfoDto = new UserInfoDto(user.getId(), user.getFirstName(),
+                user.getImageUrl());
+
+
+            getTourDatesResponses.add(new GetTourParticipantsResponse(tourHistory.getId(), tourDate.getId(),
+                tourDate.getDate(), tourDate.getTime(), tourDate.getStatus(), userInfoDto));
+        }
+        return getTourDatesResponses;
     }
 
 }


### PR DESCRIPTION
- 해당 투어에 참여 요청을 보낸 유저의 리스트들을 볼 수 있습니다.
- 유저 정보, 투어 날짜, 투어 히스토리 아이디를 반환하며, 투어 히스토리 아이디를 통해 참여 요청 상태를 CONFIRED로 바꿔 매칭을 확정지을 수 있습니다.